### PR TITLE
Only init required SDL subsystems

### DIFF
--- a/src/sdlengine.h
+++ b/src/sdlengine.h
@@ -8,7 +8,7 @@ struct SDLEngine
 {
     SDLEngine()
     {
-        if (SDL_Init(SDL_INIT_EVERYTHING) != 0) {
+        if (SDL_Init(SDL_INIT_VIDEO) != 0) {
             throw std::runtime_error("SDL_Init");
         }
         if (SDL_ShowCursor(SDL_DISABLE) < 0) {


### PR DESCRIPTION
For instance, SDL_Init(SDL_INIT_EVERYTHING) fails on FreeBSD as SDL_INIT_HAPTIC is not implemented.
