### PR TITLE
Now the window can be closed normally.

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -65,6 +65,9 @@ void Game::runEventLoop() {
             case SDL_KEYUP:
                 input.keyUpEvent(event);
                 break;
+            case SDL_QUIT:
+                running = false;
+                break;
             default:
                 break;
             }


### PR DESCRIPTION
I noticed that the SDL window didn't respond when I pressed the X button or hit Alt-F4, so I added this little bit of code.